### PR TITLE
refactor: change async method return types to ICollection and update …

### DIFF
--- a/ArmoniK.Extension.CSharp.Client.DllHelper/ArmoniKServicesExt.cs
+++ b/ArmoniK.Extension.CSharp.Client.DllHelper/ArmoniKServicesExt.cs
@@ -86,7 +86,7 @@ public static class ArmoniKServicesExt
   /// <param name="dllBlob">The dynamic library blob dependency for the tasks.</param>
   /// <param name="manualDeletion">Whether the blob should be deleted manually.</param>
   /// <param name="cancellationToken">A token to monitor for cancellation requests during the task submission process.</param>
-  public static async Task<IEnumerable<TaskInfos>> SubmitTasksWithDllAsync(this ITasksService       taskService,
+  public static async Task<ICollection<TaskInfos>> SubmitTasksWithDllAsync(this ITasksService       taskService,
                                                                            SessionInfo              session,
                                                                            IEnumerable<TaskNodeExt> taskNodes,
                                                                            DllBlob                  dllBlob,

--- a/ArmoniK.Extension.CSharp.Client/Common/Services/IBlobService.cs
+++ b/ArmoniK.Extension.CSharp.Client/Common/Services/IBlobService.cs
@@ -129,7 +129,7 @@ public interface IBlobService
   /// <param name="blobDescs">The BlobInfo associated with its OpaqueId.</param>
   /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
   /// <returns></returns>
-  Task<IEnumerable<BlobState>> ImportBlobDataAsync(SessionInfo                                 session,
+  Task<ICollection<BlobState>> ImportBlobDataAsync(SessionInfo                                 session,
                                                    IEnumerable<KeyValuePair<BlobInfo, byte[]>> blobDescs,
                                                    CancellationToken                           cancellationToken = default);
 }

--- a/ArmoniK.Extension.CSharp.Client/Common/Services/ITasksService.cs
+++ b/ArmoniK.Extension.CSharp.Client/Common/Services/ITasksService.cs
@@ -41,7 +41,7 @@ public interface ITasksService
   /// <param name="manualDeletion">Whether the blobs should be deleted manually.</param>
   /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
   /// <returns>A task representing the asynchronous operation. The task result contains an enumerable of task information.</returns>
-  Task<IEnumerable<TaskInfos>> SubmitTasksAsync(SessionInfo           session,
+  Task<ICollection<TaskInfos>> SubmitTasksAsync(SessionInfo           session,
                                                 IEnumerable<TaskNode> taskNodes,
                                                 bool                  manualDeletion    = false,
                                                 CancellationToken     cancellationToken = default);
@@ -81,7 +81,7 @@ public interface ITasksService
   /// <param name="taskIds">The identifiers of the tasks to cancel.</param>
   /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
   /// <returns>A task representing the asynchronous operation. The task result contains an enumerable of task state.</returns>
-  Task<IEnumerable<TaskState>> CancelTasksAsync(IEnumerable<string> taskIds,
+  Task<ICollection<TaskState>> CancelTasksAsync(IEnumerable<string> taskIds,
                                                 CancellationToken   cancellationToken = default);
 }
 

--- a/ArmoniK.Extension.CSharp.Client/Services/BlobService.cs
+++ b/ArmoniK.Extension.CSharp.Client/Services/BlobService.cs
@@ -317,7 +317,7 @@ public class BlobService : IBlobService
     var response = await blobClient.ImportResultsDataAsync(request)
                                    .ConfigureAwait(false);
     return response.Results.Select(resultRaw => resultRaw.ToBlobState())
-                   .ToList();
+                   .AsICollection();
   }
 
   private async Task LoadBlobServiceConfigurationAsync(CancellationToken cancellationToken = default)

--- a/ArmoniK.Extension.CSharp.Client/Services/BlobService.cs
+++ b/ArmoniK.Extension.CSharp.Client/Services/BlobService.cs
@@ -294,7 +294,7 @@ public class BlobService : IBlobService
     }
   }
 
-  public async Task<IEnumerable<BlobState>> ImportBlobDataAsync(SessionInfo                                 session,
+  public async Task<ICollection<BlobState>> ImportBlobDataAsync(SessionInfo                                 session,
                                                                 IEnumerable<KeyValuePair<BlobInfo, byte[]>> blobDescs,
                                                                 CancellationToken                           cancellationToken = default)
   {
@@ -316,7 +316,8 @@ public class BlobService : IBlobService
 
     var response = await blobClient.ImportResultsDataAsync(request)
                                    .ConfigureAwait(false);
-    return response.Results.Select(resultRaw => resultRaw.ToBlobState());
+    return response.Results.Select(resultRaw => resultRaw.ToBlobState())
+                   .ToList();
   }
 
   private async Task LoadBlobServiceConfigurationAsync(CancellationToken cancellationToken = default)

--- a/ArmoniK.Extension.CSharp.Client/Services/TasksService.cs
+++ b/ArmoniK.Extension.CSharp.Client/Services/TasksService.cs
@@ -63,7 +63,7 @@ public class TasksService : ITasksService
     blobService_ = blobService;
   }
 
-  public async Task<IEnumerable<TaskInfos>> SubmitTasksAsync(SessionInfo           session,
+  public async Task<ICollection<TaskInfos>> SubmitTasksAsync(SessionInfo           session,
                                                              IEnumerable<TaskNode> taskNodes,
                                                              bool                  manualDeletion    = false,
                                                              CancellationToken     cancellationToken = default)
@@ -111,7 +111,8 @@ public class TasksService : ITasksService
                                                   .ConfigureAwait(false);
 
     return taskSubmissionResponse.TaskInfos.Select(x => new TaskInfos(x,
-                                                                      session.SessionId));
+                                                                      session.SessionId))
+                                 .ToList();
   }
 
   public async IAsyncEnumerable<TaskPage> ListTasksAsync(TaskPagination                             paginationOptions,
@@ -190,7 +191,7 @@ public class TasksService : ITasksService
                  };
   }
 
-  public async Task<IEnumerable<TaskState>> CancelTasksAsync(IEnumerable<string> taskIds,
+  public async Task<ICollection<TaskState>> CancelTasksAsync(IEnumerable<string> taskIds,
                                                              CancellationToken   cancellationToken = default)
   {
     await using var channel = await channelPool_.GetAsync(cancellationToken)
@@ -206,7 +207,8 @@ public class TasksService : ITasksService
                                                         },
                                                       })
                                     .ConfigureAwait(false);
-    return response.Tasks.Select(taskSummary => taskSummary.ToTaskState());
+    return response.Tasks.Select(taskSummary => taskSummary.ToTaskState())
+                   .ToList();
   }
 
   private async Task CreateNewBlobsAsync(SessionInfo           session,

--- a/ArmoniK.Extension.CSharp.Client/Services/TasksService.cs
+++ b/ArmoniK.Extension.CSharp.Client/Services/TasksService.cs
@@ -112,7 +112,7 @@ public class TasksService : ITasksService
 
     return taskSubmissionResponse.TaskInfos.Select(x => new TaskInfos(x,
                                                                       session.SessionId))
-                                 .ToList();
+                                 .AsICollection();
   }
 
   public async IAsyncEnumerable<TaskPage> ListTasksAsync(TaskPagination                             paginationOptions,
@@ -208,7 +208,7 @@ public class TasksService : ITasksService
                                                       })
                                     .ConfigureAwait(false);
     return response.Tasks.Select(taskSummary => taskSummary.ToTaskState())
-                   .ToList();
+                   .AsICollection();
   }
 
   private async Task CreateNewBlobsAsync(SessionInfo           session,

--- a/Tests/Services/TasksServiceTests.cs
+++ b/Tests/Services/TasksServiceTests.cs
@@ -199,16 +199,28 @@ public class TasksServiceTests
                                                             taskNodes)
                              .ConfigureAwait(false);
 
-    var resultList = result.ToList();
-
     Assert.Multiple(() =>
                     {
-                      Assert.That(resultList,
-                                  Has.Count.EqualTo(2));
-                      Assert.That(resultList[0].TaskId,
-                                  Is.EqualTo("taskId1"));
-                      Assert.That(resultList[1].TaskId,
-                                  Is.EqualTo("taskId2"));
+                      Assert.That(result,
+                                  Is.Not.Null,
+                                  "Result should not be null.");
+                      Assert.That(result.Count,
+                                  Is.EqualTo(2),
+                                  "Expected two task infos in the response.");
+                      Assert.That(result.Select(t => t.TaskId),
+                                  Is.EqualTo(new[]
+                                             {
+                                               "taskId1",
+                                               "taskId2",
+                                             }),
+                                  "Expected task IDs to match.");
+                      Assert.That(result.Select(t => t.PayloadId),
+                                  Is.EqualTo(new[]
+                                             {
+                                               "payloadId1",
+                                               "payloadId2",
+                                             }),
+                                  "Expected payload IDs to match.");
                     });
   }
 
@@ -806,12 +818,23 @@ public class TasksServiceTests
     Assert.Multiple(() =>
                     {
                       Assert.That(result,
-                                  Is.Not.Null);
+                                  Is.Not.Null,
+                                  "Result should not be null.");
                       Assert.That(result.Count,
-                                  Is.EqualTo(1));
+                                  Is.EqualTo(1),
+                                  "Expected one task info in the response.");
                       Assert.That(result.First()
                                         .TaskId,
-                                  Is.EqualTo("taskId1"));
+                                  Is.EqualTo("taskId1"),
+                                  "Expected task ID to match.");
+                      Assert.That(result.First()
+                                        .PayloadId,
+                                  Is.EqualTo("payloadId1"),
+                                  "Expected payload ID to match.");
+                      Assert.That(result.First()
+                                        .ExpectedOutputs.First(),
+                                  Is.EqualTo("outputId1"),
+                                  "Expected output ID to match.");
                     });
   }
 

--- a/Tests/Services/TasksServiceTests.cs
+++ b/Tests/Services/TasksServiceTests.cs
@@ -21,7 +21,6 @@ using ArmoniK.Extension.CSharp.Client.Common.Domain.Blob;
 using ArmoniK.Extension.CSharp.Client.Common.Domain.Session;
 using ArmoniK.Extension.CSharp.Client.Common.Domain.Task;
 using ArmoniK.Extension.CSharp.Client.Common.Enum;
-using ArmoniK.Utils;
 
 using Google.Protobuf.WellKnownTypes;
 
@@ -198,18 +197,19 @@ public class TasksServiceTests
 
     var result = await client.TasksService.SubmitTasksAsync(new SessionInfo("sessionId1"),
                                                             taskNodes)
-                             .ToListAsync()
                              .ConfigureAwait(false);
-    Assert.That(result,
-                Has.Count.EqualTo(2),
-                "Result should contain two task infos");
 
-    Assert.That(result,
-                Has.Some.Matches<TaskInfos>(r => r.TaskId == "taskId1" && r.PayloadId == "payloadId1" && r.ExpectedOutputs.Contains("outputId1")),
-                "Result should contain an item with taskId1, payloadId1, and outputId1");
-    Assert.That(result,
-                Has.Some.Matches<TaskInfos>(r => r.TaskId == "taskId2" && r.PayloadId == "payloadId2" && r.ExpectedOutputs.Contains("outputId2")),
-                "Result should contain an item with taskId2, payloadId2, and outputId2");
+    var resultList = result.ToList();
+
+    Assert.Multiple(() =>
+                    {
+                      Assert.That(resultList,
+                                  Has.Count.EqualTo(2));
+                      Assert.That(resultList[0].TaskId,
+                                  Is.EqualTo("taskId1"));
+                      Assert.That(resultList[1].TaskId,
+                                  Is.EqualTo("taskId2"));
+                    });
   }
 
 
@@ -606,7 +606,34 @@ public class TasksServiceTests
   {
     var client = new MockedArmoniKClient();
 
-    client.CallInvokerMock.SetupAsyncUnaryCallInvokerMock<CancelTasksRequest, CancelTasksResponse>(new CancelTasksResponse());
+    var cancelResponse = new CancelTasksResponse
+                         {
+                           Tasks =
+                           {
+                             new TaskSummary
+                             {
+                               Id        = "taskId1",
+                               Status    = V1_TaskStatus.Cancelled,
+                               CreatedAt = Timestamp.FromDateTime(DateTime.UtcNow.AddMinutes(-10)),
+                               StartedAt = Timestamp.FromDateTime(DateTime.UtcNow.AddMinutes(-5)),
+                               EndedAt   = Timestamp.FromDateTime(DateTime.UtcNow),
+                               SessionId = "sessionId1",
+                               PayloadId = "payloadId1",
+                             },
+                             new TaskSummary
+                             {
+                               Id        = "taskId2",
+                               Status    = V1_TaskStatus.Cancelled,
+                               CreatedAt = Timestamp.FromDateTime(DateTime.UtcNow.AddMinutes(-8)),
+                               StartedAt = Timestamp.FromDateTime(DateTime.UtcNow.AddMinutes(-3)),
+                               EndedAt   = Timestamp.FromDateTime(DateTime.UtcNow),
+                               SessionId = "sessionId1",
+                               PayloadId = "payloadId2",
+                             },
+                           },
+                         };
+
+    client.CallInvokerMock.SetupAsyncUnaryCallInvokerMock<CancelTasksRequest, CancelTasksResponse>(cancelResponse);
 
     var taskIds = new List<string>
                   {
@@ -614,15 +641,26 @@ public class TasksServiceTests
                     "taskId2",
                   };
 
-    await client.TasksService.CancelTasksAsync(taskIds)
-                .ConfigureAwait(false);
+    var result = await client.TasksService.CancelTasksAsync(taskIds)
+                             .ConfigureAwait(false);
 
-    client.CallInvokerMock.Verify(invoker => invoker.AsyncUnaryCall(It.IsAny<Method<CancelTasksRequest, CancelTasksResponse>>(),
-                                                                    It.IsAny<string>(),
-                                                                    It.IsAny<CallOptions>(),
-                                                                    It.Is<CancelTasksRequest>(req => req.TaskIds.Count == 2 && req.TaskIds.Contains("taskId1") &&
-                                                                                                     req.TaskIds.Contains("taskId2"))),
-                                  Times.Once);
+    Assert.Multiple(() =>
+                    {
+                      Assert.That(result,
+                                  Is.Not.Null);
+                      Assert.That(result.Count,
+                                  Is.EqualTo(2));
+
+                      var resultList = result.ToList();
+                      Assert.That(resultList[0].TaskId,
+                                  Is.EqualTo("taskId1"));
+                      Assert.That(resultList[0].Status,
+                                  Is.EqualTo(TaskStatus.Cancelled));
+                      Assert.That(resultList[1].TaskId,
+                                  Is.EqualTo("taskId2"));
+                      Assert.That(resultList[1].Status,
+                                  Is.EqualTo(TaskStatus.Cancelled));
+                    });
   }
 
   [Test]
@@ -768,23 +806,12 @@ public class TasksServiceTests
     Assert.Multiple(() =>
                     {
                       Assert.That(result,
-                                  Is.Not.Null,
-                                  "Result should not be null.");
+                                  Is.Not.Null);
                       Assert.That(result.Count,
-                                  Is.EqualTo(1),
-                                  "Expected one task info in the response.");
+                                  Is.EqualTo(1));
                       Assert.That(result.First()
                                         .TaskId,
-                                  Is.EqualTo("taskId1"),
-                                  "Expected task ID to match.");
-                      Assert.That(result.First()
-                                        .PayloadId,
-                                  Is.EqualTo("payloadId1"),
-                                  "Expected payload ID to match.");
-                      Assert.That(result.First()
-                                        .ExpectedOutputs.First(),
-                                  Is.EqualTo("outputId1"),
-                                  "Expected output ID to match.");
+                                  Is.EqualTo("taskId1"));
                     });
   }
 


### PR DESCRIPTION
# Motivation
Improve API design and performance by changing return types from `Task<IEnumerable<T>>` to `Task<ICollection<T>>` in service methods. This provides better type safety, enables collection size queries without enumeration, and aligns with .NET best practices for async methods returning collections.

# Description
Updated return types from Task<IEnumerable<T>> to Task<ICollection<T>> across service interfaces and implementations in:

- ITasksService and TasksService
- IBlobService and BlobService
- Related extension methods in ArmoniKServicesExt

Modified service implementations to materialize results using .ToList() and fixed all affected unit tests to handle the new collection types properly.

# Testing
Updated all unit tests to work with ICollection<T> return types

# Impact

Usability: Better type safety for collection operations

# Additional Information

None

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [ ] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.
